### PR TITLE
fix(lead): fix space on the right for small screen

### DIFF
--- a/blocks/lead/__button/lead__button.css
+++ b/blocks/lead/__button/lead__button.css
@@ -1,5 +1,11 @@
 .lead__button {
-  margin-left: 62px;
+  margin: 0 auto;
+}
+
+@media screen and (min-width: 375px) {
+  .lead__button {
+    margin-left: 62px;
+  }
 }
 
 @media screen and (min-width: 1440px) {

--- a/blocks/lead/__date/lead__date.css
+++ b/blocks/lead/__date/lead__date.css
@@ -1,11 +1,19 @@
 .lead__date {
-  margin: 0 0 16px 62px;
+  margin: 0 auto 16px;
   font-family: "NeueMachina", Arial, Helvetica, sans-serif;
   font-weight: 400;
   font-size: 28px;
   line-height: 1.14;
   letter-spacing: -0.01em;
   color: #242424;
+  text-align: center;
+}
+
+@media screen and (min-width: 375px) {
+  .lead__date {
+    margin-left: 62px;
+    text-align: left;
+  }
 }
 
 @media screen and (min-width: 1440px) {

--- a/blocks/lead/__info/lead__info.css
+++ b/blocks/lead/__info/lead__info.css
@@ -1,5 +1,5 @@
 .lead__info {
-  margin: 0 0 31px 62px;
+  margin: 0 auto 31px;
   padding: 0;
   font-family: "NeueMachina", Arial, Helvetica, sans-serif;
   font-weight: 400;
@@ -7,6 +7,12 @@
   line-height: 1.2;
   letter-spacing: -0.01em;
   color: #242424;
+}
+
+@media screen and (min-width: 375px) {
+  .lead__info {
+    margin-left: 62px;
+  }
 }
 
 @media screen and (min-width: 1440px) {


### PR DESCRIPTION
Убрал пространство справа, появляющееся при маленьком разрешении

**Причина**: левый марджин у кнопки был слишком большой, что выталкивало ее при маленьких разрешениях.

_Решение_: убрать маржин и отцентровать кнопку для экранов <375px.